### PR TITLE
Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/packages"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
We are not keeping up with the automatically created PRs so there is no point in having this here for now.